### PR TITLE
docs: drop React route from prerender list

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -12,7 +12,6 @@ const pages = [
   '/docs/getting-started/',
   '/docs/getting-started/installation/vue/',
   '/docs/getting-started/installation/nuxt/',
-  '/docs/getting-started/installation/react/',
   '/icons/'
   // endregion ////
 ]


### PR DESCRIPTION
## Summary

Follow-up to #8 (removing the React installation page). The route `/docs/getting-started/installation/react/` was still listed in the prerender `pages` array in `docs/nuxt.config.ts`, which would now point at a non-existent page during build.

## Changes

- Remove the React route from the prerender `pages` list in `docs/nuxt.config.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHqTi6j1tX6i8trt2VPakf)_