### PR TITLE
ci: bump deprecated Node 20 actions to Node 24 versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,16 +29,16 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install node
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

Resolves the GitHub Actions Node.js 20 deprecation warning ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

## Changes

- `pnpm/action-setup` `@v4` → `@v6` (Node 24) — in `deploy.yml` and `npm-publish.yml`
- `actions/configure-pages` `@v4` → `@v6` (Node 24) — in `deploy.yml`
- Deploy build `node-version` `20` → `22` (LTS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012xEqiMc4KWCg1XTnUKduu6)_