### PR TITLE
docs: align footer with b24jssdk presentation

### DIFF
--- a/docs/app/components/Footer.vue
+++ b/docs/app/components/Footer.vue
@@ -1,23 +1,77 @@
 <script setup lang="ts">
 import RocketIcon from '@bitrix24/b24icons-vue/outline/RocketIcon'
+import Bitrix24Icon from '@bitrix24/b24icons-vue/common-service/Bitrix24Icon'
+import TelegramIcon from '@bitrix24/b24icons-vue/outline/TelegramIcon'
+import GitHubIcon from '@bitrix24/b24icons-vue/social/GitHubIcon'
 
+const route = useRoute()
 const config = useRuntimeConfig()
+
+const isNeedChangeTarget = ref(false)
+const tgLink = computed(() => {
+  return (
+    isNeedChangeTarget.value && (typeof window !== 'undefined' && window.navigator?.language.includes('ru'))
+  )
+    ? 'https://t.me/bitrix24apps'
+    : 'https://t.me/b24_dev'
+})
+
+const b24DocsLink = computed(() => {
+  return (
+    isNeedChangeTarget.value && (typeof window !== 'undefined' && window.navigator?.language.includes('ru'))
+  )
+    ? 'https://apidocs.bitrix24.ru/'
+    : 'https://apidocs.bitrix24.com/'
+})
+
+onMounted(() => {
+  isNeedChangeTarget.value = true
+})
 </script>
 
 <template>
-  <div class="mx-[22px] my-[12px] flex flex-col sm:flex-row items-center justify-start gap-[12px]">
-    <B24Button
-      label="Releases"
-      :icon="RocketIcon"
-      :to="`${config.public.gitUrl}/releases`"
-      target="_blank"
-      size="md"
-    />
-    <NuxtLink :to="config.public.gitUrl" target="_blank" class="text-(length:--ui-font-size-sm) hover:underline">
+  <B24Separator :icon="route.path === '/' ? undefined : Bitrix24Icon" class="h-px" />
+
+  <B24Footer>
+    <template #left>
+      <ProseP small accent="less">
+        Copyright © 2024-present Bitrix24
+      </ProseP>
+    </template>
+
+    <template #right>
+      <B24Button
+        aria-label="Bitrix24 REST API"
+        :icon="Bitrix24Icon"
+        :to="b24DocsLink"
+        target="_blank"
+        size="md"
+      />
+      <B24Button
+        aria-label="Bitrix24 Icons on Telegram"
+        :icon="TelegramIcon"
+        :to="tgLink"
+        target="_blank"
+        size="md"
+      />
+      <B24Button
+        aria-label="Bitrix24 Icons on GitHub"
+        :icon="GitHubIcon"
+        :to="config.public.gitUrl"
+        target="_blank"
+        size="md"
+      />
+      <B24Button
+        label="Releases"
+        :icon="RocketIcon"
+        :to="`${config.public.gitUrl}/releases`"
+        target="_blank"
+        size="md"
+      />
+    </template>
+
+    <NuxtLink :to="config.public.gitUrl" target="_blank" class="text-legend text-(length:--ui-font-size-sm) hover:underline">
       Published under MIT License.
     </NuxtLink>
-    <ProseP small accent="less">
-      Copyright © 2024-present Bitrix24
-    </ProseP>
-  </div>
+  </B24Footer>
 </template>


### PR DESCRIPTION
## Summary

Step toward a visually identical page template with [b24jssdk](https://bitrix24.github.io/b24jssdk/). The footer was the one piece of page chrome that diverged — it used an ad-hoc flex `<div>` instead of the shared `B24Footer` layout.

## Changes

- Rebuild `Footer.vue` on the `B24Footer` component + `B24Separator`, matching the b24jssdk structure (`#left` copyright / `#right` action buttons / MIT license line).
- Use the same link set as the header: Bitrix24 REST API, Telegram, GitHub, plus Releases.

## Verification

- Full `pnpm --filter @bitrix24/b24icons-docs build` completes successfully (all pages prerendered, OG image routes generated).

## Notes on remaining parity

After this, the page **chrome** (header, footer, docs page template with PageHeader + TOC + surround nav, 404) is at visual parity with b24jssdk. The home page (`pages/index.vue`) intentionally still differs because its content is icon-specific (icon gallery hero) rather than the SDK landing sections — that's product content, not template. Happy to align the home layout too if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHqTi6j1tX6i8trt2VPakf)_